### PR TITLE
fixed TypeError : Cannot read property 'trim' of undefined

### DIFF
--- a/client/src/components/Messages/Message/Message.js
+++ b/client/src/components/Messages/Message/Message.js
@@ -7,7 +7,7 @@ import ReactEmoji from 'react-emoji';
 const Message = ({ message: { text, user }, name }) => {
   let isSentByCurrentUser = false;
 
-  const trimmedName = name.trim().toLowerCase();
+  const trimmedName = name ? name.trim().toLowerCase() : '';
 
   if(user === trimmedName) {
     isSentByCurrentUser = true;


### PR DESCRIPTION
fixes #54 

change: 
const trimmedName = name ? name.trim().toLowerCase() : '';

explanation: To fix this error, you should ensure that the name property is properly defined and not null before trying to manipulate it. You can add a conditional check to make sure name is defined before using it.
